### PR TITLE
[INFRA-251] Allow two Syncano lib version in codebox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:trusty
 MAINTAINER "Syncano DevOps Team" <devops@syncano.com>
 
-ENV LAST_REFRESHED 2016-01-11
+ENV LAST_REFRESHED 2016-03-17
 ENV export SYNCANO_APIROOT='https://api.syncano.io/'
 
 COPY requirements.txt /tmp/requirements.txt
@@ -15,12 +15,21 @@ RUN apt-get update && apt-get install -qqy \
     python-dev \
     python-numpy \
     python-scipy \
-    wget \
-    && wget https://bootstrap.pypa.io/get-pip.py \
-    && python get-pip.py \
-    && pip install --upgrade pip \
-    && pip install -r /tmp/requirements.txt \
-    && pip install -r /tmp/external_requirements.txt
+    wget && \
+    wget https://bootstrap.pypa.io/get-pip.py && \
+    python get-pip.py && \
+    pip install --upgrade pip && \
+    pip install -r /tmp/requirements.txt && \
+    pip install -r /tmp/external_requirements.txt && \
+    pip install syncano==4.2.0
+
+RUN mkdir /home/syncano && \
+    cd /home/syncano/ && \
+    virtualenv deprecated && \
+    . new_syncano/bin/activate && \
+    pip install -r /tmp/requirements.txt && \
+    pip install -r /tmp/external_requirements.txt && \
+    pip install syncano==4.1.0
 
 # create a special user to run code
 # user without root privileges greatly improves security

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,15 +21,15 @@ RUN apt-get update && apt-get install -qqy \
     pip install --upgrade pip && \
     pip install -r /tmp/requirements.txt && \
     pip install -r /tmp/external_requirements.txt && \
-    pip install syncano==4.2.0
+    pip install syncano==4.1.0
 
 RUN mkdir /home/syncano && \
     cd /home/syncano/ && \
-    virtualenv deprecated && \
-    . new_syncano/bin/activate && \
+    virtualenv new && \
+    . new/bin/activate && \
     pip install -r /tmp/requirements.txt && \
     pip install -r /tmp/external_requirements.txt && \
-    pip install syncano==4.1.0
+    pip install syncano==4.2.0
 
 # create a special user to run code
 # user without root privileges greatly improves security

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update && apt-get install -qqy \
     wget && \
     wget https://bootstrap.pypa.io/get-pip.py && \
     python get-pip.py && \
-    pip install --upgrade pip && \
     pip install -r /tmp/requirements_base.txt && \
     mkdir /home/syncano
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 FROM ubuntu:trusty
 MAINTAINER "Syncano DevOps Team" <devops@syncano.com>
 
-ENV LAST_REFRESHED 2016-03-17
+ENV LAST_REFRESHED 2016-03-18
 ENV export SYNCANO_APIROOT='https://api.syncano.io/'
 
-COPY requirements.txt /tmp/requirements.txt
-COPY external_requirements.txt /tmp/external_requirements.txt
+COPY *requirements*.txt /tmp/
 
 RUN apt-get update && apt-get install -qqy \
     git \
@@ -19,22 +18,28 @@ RUN apt-get update && apt-get install -qqy \
     wget https://bootstrap.pypa.io/get-pip.py && \
     python get-pip.py && \
     pip install --upgrade pip && \
-    pip install -r /tmp/requirements.txt && \
-    pip install -r /tmp/external_requirements.txt && \
-    pip install syncano==4.1.0
+    pip install -r /tmp/requirements_base.txt && \
+    mkdir /home/syncano
 
-RUN mkdir /home/syncano && \
-    cd /home/syncano/ && \
-    virtualenv new && \
-    . new/bin/activate && \
-    pip install -r /tmp/requirements.txt && \
-    pip install -r /tmp/external_requirements.txt && \
-    pip install syncano==4.2.0
+RUN cd /home/syncano/ && \
+    virtualenv v4.1 && \
+    . v4.1/bin/activate && \
+    pip install -r /tmp/requirements_v41.txt && \
+    pip install -r /tmp/external_requirements.txt
 
+RUN cd /home/syncano/ && \
+    virtualenv v4.2 && \
+    . v4.2/bin/activate && \
+    pip install -r /tmp/requirements.txt && \
+    pip install -r /tmp/external_requirements.txt
+
+RUN ln -sf /home/syncano/v4.1/bin/python /usr/bin/python && \
+    ln -sf /home/syncano/v4.2/bin/python /usr/bin/python27-42 && \
+    ln -sf /home/syncano/v4.1/bin/python /usr/bin/python27-41
 # create a special user to run code
 # user without root privileges greatly improves security
 RUN useradd syncano -d /tmp -s /bin/bash
 RUN chmod 1777 /tmp
 
 USER syncano
-CMD ["python"]
+CMD "python"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,14 @@ RUN apt-get update && apt-get install -qqy \
     pip install -r /tmp/requirements_base.txt && \
     mkdir /home/syncano
 
-RUN cd /home/syncano/ && \
-    virtualenv v4.1 && \
+WORKDIR /home/syncano/
+RUN virtualenv v4.1 && \
     . v4.1/bin/activate && \
     pip install -r /tmp/requirements_v41.txt && \
-    pip install -r /tmp/external_requirements.txt
+    pip install -r /tmp/external_requirements.txt && \
+    deactivate
 
-RUN cd /home/syncano/ && \
-    virtualenv v4.2 && \
+RUN virtualenv v4.2 && \
     . v4.2/bin/activate && \
     pip install -r /tmp/requirements.txt && \
     pip install -r /tmp/external_requirements.txt
@@ -41,5 +41,6 @@ RUN ln -sf /home/syncano/v4.1/bin/python /usr/bin/python && \
 RUN useradd syncano -d /tmp -s /bin/bash
 RUN chmod 1777 /tmp
 
+WORKDIR /tmp
 USER syncano
 CMD "python"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Type "help", "copyright", "credits" or "license" for more information.
 >>>
 ```
 
-In a container, you can use Syncano's Python Library:
+In a container you can use Syncano's Python Library:
 
 ```
 >>> import syncano

--- a/circle.yml
+++ b/circle.yml
@@ -9,9 +9,9 @@ dependencies:
 test:
   override:
     - docker run -it -v `pwd`/test.py:/tmp/test.py quay.io/syncano/python-codebox python /tmp/test.py
-    - docker run -it -v `pwd`/test.py:/tmp/test.py quay.io/syncano/python-codebox /home/syncano/deprecated/bin/python /tmp/test.py
-    - docker run -it -v `pwd`/test2.py:/tmp/test.py quay.io/syncano/python-codebox /home/syncano/deprecated/bin/python /tmp/test.py
-    - docker run -it -v `pwd`/test3.py:/tmp/test.py quay.io/syncano/python-codebox python /tmp/test.py
+    - docker run -it -v `pwd`/test.py:/tmp/test.py quay.io/syncano/python-codebox /home/syncano/new/bin/python /tmp/test.py
+    - docker run -it -v `pwd`/test2.py:/tmp/test.py quay.io/syncano/python-codebox python /tmp/test.py
+    - docker run -it -v `pwd`/test3.py:/tmp/test.py quay.io/syncano/python-codebox /home/syncano/new/bin/python /tmp/test.py
 
 deployment:
   production:

--- a/circle.yml
+++ b/circle.yml
@@ -9,9 +9,9 @@ dependencies:
 test:
   override:
     - docker run -it -v `pwd`/test.py:/tmp/test.py quay.io/syncano/python-codebox python /tmp/test.py
-    - docker run -it -v `pwd`/test.py:/tmp/test.py quay.io/syncano/python-codebox /home/syncano/new/bin/python /tmp/test.py
+    - docker run -it -v `pwd`/test.py:/tmp/test.py quay.io/syncano/python-codebox python27-42 /tmp/test.py
     - docker run -it -v `pwd`/test2.py:/tmp/test.py quay.io/syncano/python-codebox python /tmp/test.py
-    - docker run -it -v `pwd`/test3.py:/tmp/test.py quay.io/syncano/python-codebox /home/syncano/new/bin/python /tmp/test.py
+    - docker run -it -v `pwd`/test3.py:/tmp/test.py quay.io/syncano/python-codebox python27-42 /tmp/test.py
 
 deployment:
   production:

--- a/circle.yml
+++ b/circle.yml
@@ -4,12 +4,14 @@ machine:
 
 dependencies:
   override:
-    - sed -i 's/CMD/#CMD/g' Dockerfile
     - docker build -t quay.io/syncano/python-codebox .
 
 test:
   override:
-    -  docker run -it -v `pwd`/test.py:/tmp/test.py quay.io/syncano/python-codebox python /tmp/test.py
+    - docker run -it -v `pwd`/test.py:/tmp/test.py quay.io/syncano/python-codebox python /tmp/test.py
+    - docker run -it -v `pwd`/test.py:/tmp/test.py quay.io/syncano/python-codebox /home/syncano/deprecated/bin/python /tmp/test.py
+    - docker run -it -v `pwd`/test2.py:/tmp/test.py quay.io/syncano/python-codebox /home/syncano/deprecated/bin/python /tmp/test.py
+    - docker run -it -v `pwd`/test3.py:/tmp/test.py quay.io/syncano/python-codebox python /tmp/test.py
 
 deployment:
   production:
@@ -17,6 +19,4 @@ deployment:
       - master
     commands:
       - sed -e "s|<REGISTRY>|$DOCKER_REGISTRY|g" -e "s|<EMAIL>|$DOCKER_EMAIL|g" -e "s|<AUTH>|$DOCKER_AUTH|g" < .dockercfg.template > ~/.dockercfg
-      - sed -i 's/#CMD/CMD/g' Dockerfile
-      - docker build -t quay.io/syncano/python-codebox .
       - docker push quay.io/syncano/python-codebox

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,8 @@ requests-oauthlib==0.5.0
 tweepy==3.4.0
 braintree==3.20.0
 googleads==3.11.0
-syncano==4.1.0
 fastly==0.0.2
 pandas==0.17.1
 BeautifulSoup==3.2.1
 boto3==1.2.5
+virtualenv==13.0.3

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -1,0 +1,1 @@
+virtualenv==13.0.3

--- a/requirements_v41.txt
+++ b/requirements_v41.txt
@@ -23,4 +23,4 @@ fastly==0.0.2
 pandas==0.17.1
 BeautifulSoup==3.2.1
 boto3==1.2.5
-syncano==4.2.0
+syncano==4.1.0

--- a/test2.py
+++ b/test2.py
@@ -1,0 +1,2 @@
+import syncano
+assert syncano.__version__ == '4.1.0'

--- a/test3.py
+++ b/test3.py
@@ -1,0 +1,2 @@
+import syncano
+assert syncano.__version__ == '4.2.0'


### PR DESCRIPTION
Deprecated version run with:

```
docker run -it quay.io/syncano/python-codebox test.py
```

or

```
docker run -it quay.io/syncano/python-codebox python test.py
```

The new version

```
docker run -it quay.io/syncano/python-codebox python27-42 test.py
```
