### PR TITLE
Add new packages, upgrade google-api-python-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update && apt-get install -qqy \
     libjpeg-dev \
     python-dev \
     python3-dev \
+    python-tk \
+    python3-tk \
     python-numpy \
     python3-numpy \
     python-scipy \

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ twilio==4.4.0
 qrcode==5.1
 analytics-python==1.0.3
 osa==0.1.6.6
-google-api-python-client==1.4.1
+google-api-python-client==1.5.2
 six==1.9.0
 uritemplate==0.6
 oauth2client==1.4.11
@@ -29,3 +29,7 @@ mixpanel-query-py==0.1.7
 Sendinblue==2.0.2
 GitPython==2.0.5
 Mako==1.0.4
+sendgrid==3.2.10
+python-telegram-bot==5.0.0
+Jinja2==2.8
+wit==4.1.0

--- a/test.py
+++ b/test.py
@@ -1,5 +1,6 @@
 if __name__ == '__main__':
     import pkgutil
+    blacklist = ['winreg']
     modules = (name for _, name, is_pkg in pkgutil.iter_modules()
-               if is_pkg)
+               if is_pkg and name not in blacklist)
     map(__import__, modules)


### PR DESCRIPTION
Added:
+sendgrid==3.2.10
+python-telegram-bot==5.0.0
+Jinja2==2.8
+wit==4.1.0

Upgraded:
+google-api-python-client==1.5.2 (from 1.4.1)
