### PR TITLE
[sendinblue] Force updated

### DIFF
--- a/python/files/requirements.txt
+++ b/python/files/requirements.txt
@@ -26,7 +26,7 @@ boto3==1.2.5
 syncano==5.4.6
 mixpanel==4.3.0
 mixpanel-query-py==0.1.7
-Sendinblue==2.0.4
+Sendinblue==2.0.5.1
 GitPython==2.0.5
 Mako==1.0.4
 sendgrid==3.2.10


### PR DESCRIPTION
Due to incredibly stupid policy on behalf of sendinblue (they remove older versions from PyPI when they release new ones).